### PR TITLE
Fix an error with message reading

### DIFF
--- a/fsw/src/cratous_app.c
+++ b/fsw/src/cratous_app.c
@@ -1166,6 +1166,10 @@ void CRATOUS_AppMain()
         //Read any messages UxAS has posted
         while(nread == max_message_length && !errno){
             nread = read(sockfd, messageBuffer, max_message_length);
+            if(nread < 0){
+                fprintf(stderr, "CRATOUS: Nonfatal: error in socket read");
+                nread = 0;
+            }
             bytesReceived += nread;
         }
         messageBuffer[bytesReceived] = '\0'; //makes sure we never segfault


### PR DESCRIPTION
This fixes a logical error around the read() call that gets messages from UxAS. Previously, any negative return from read() (i.e. -1, in case of an error within the function) would cause an error propagation in CRATOUS message processing.